### PR TITLE
Add IbClientAdapter#ib_client_connected?

### DIFF
--- a/lib/ib_ruby_proxy/server/ib_client_adapter.rb
+++ b/lib/ib_ruby_proxy/server/ib_client_adapter.rb
@@ -26,6 +26,10 @@ module IbRubyProxy
         @ib_wrapper_adapter = ib_wrapper_adapter
       end
 
+      def ib_client_connected?
+        @ib_client.isConnected
+      end
+
       # @param [IbRubyProxy::Client::IbCallbacksObserver] ib_callbacks_observer
       def add_ib_callbacks_observer(ib_callbacks_observer)
         ib_wrapper_adapter.add_observer(ib_callbacks_observer)


### PR DESCRIPTION
This method returns the status of the client. It can be used like so:

```ruby
DRbObject.new_with_uri("druby://localhost:1992").ib_client_connected?
```

This is useful for liveness probes and health checks when running in a production system.